### PR TITLE
Minor Fixes to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Official Python library for Holiday API
 ## Installation
 
 ```shell
-pip install holidayapi
+pip install python-holidayapi
 ```
 
 ## Usage
@@ -15,17 +15,17 @@ import holidayapi
 hapi = holidayapi.v1('_YOUR_API_KEY_')
 
 parameters = {
-    # Required
-    country: 'US',
-     year:    2016,
-     # Optional
-     # month:    7,
-     # day:      4,
-     # previous: true,
-     # upcoming: true,
-     # public:   true,
-     # pretty:   true,
+	# Required
+	'country': 'US',
+	'year':    2016,
+	# Optional
+	# 'month':    7,
+	# 'day':      4,
+	# 'previous': True,
+	# 'upcoming': True,
+	# 'public':   True,
+	# 'pretty':   True,
 }
 
-holidays = hapi.holidays(parameters);
+holidays = hapi.holidays(parameters)
 ```


### PR DESCRIPTION
- Pip uses the package name python-holidayapi rather than holidayapi
- Python needs quotes around strings for parameters. Otherwise it's an unrecognized variable.
- Python constants need to start with a captial letter - I.E. "True" instead of "true"
- Semi-colon at the end of the last line is not necessary and probably won't work.

I tried to use tabs instead of spaces for the code section, but that may not be displaying correctly. Let me know if you'd like different formatting there.

This is my first pull request, so don't eat me alive. :-) I've tested these changes and they work on my Linux machine. Thanks for the API! It's going to be just what I need.